### PR TITLE
Add zstandard request and response compression

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -409,6 +409,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "async-compression"
+version = "0.4.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df895a515f70646414f4b45c0b79082783b80552b373a68283012928df56f522"
+dependencies = [
+ "futures-core",
+ "memchr",
+ "pin-project-lite",
+ "tokio",
+ "zstd",
+ "zstd-safe",
+]
+
+[[package]]
 name = "async-trait"
 version = "0.1.83"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2695,7 +2709,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4979f22fdb869068da03c9f7528f8297c6fd2606bc3a4affe42e6a823fdb8da4"
 dependencies = [
  "cfg-if",
- "windows-targets 0.52.6",
+ "windows-targets 0.48.5",
 ]
 
 [[package]]
@@ -4076,6 +4090,7 @@ version = "0.12.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a77c62af46e79de0a562e1a9849205ffcb7fc1238876e9bd743357570e04046f"
 dependencies = [
+ "async-compression",
  "base64 0.22.1",
  "bytes",
  "encoding_rs",
@@ -4834,6 +4849,7 @@ dependencies = [
 name = "sindri-rs"
 version = "0.1.0"
 dependencies = [
+ "async-compression",
  "async-trait",
  "base64 0.22.1",
  "console",
@@ -4855,6 +4871,7 @@ dependencies = [
  "temp-env",
  "tempfile",
  "tokio",
+ "tokio-util",
  "tracing",
  "tracing-subscriber",
  "tracing-test",
@@ -5660,9 +5677,9 @@ dependencies = [
 
 [[package]]
 name = "tokio-util"
-version = "0.7.12"
+version = "0.7.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "61e7c3654c13bcd040d4a03abee2c75b1d14a37b423cf5a813ceae1cc903ec6a"
+checksum = "d7fcaa8d55a2bdd6b83ace262b016eca0d79ee02818c5c1bcdf0305114081078"
 dependencies = [
  "bytes",
  "futures-core",
@@ -6238,7 +6255,7 @@ version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cf221c93e13a30d793f7645a0e7762c55d169dbb0a49671918a2319d289b10bb"
 dependencies = [
- "windows-sys 0.59.0",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]
@@ -6601,4 +6618,32 @@ dependencies = [
  "sha2",
  "sha3",
  "subtle",
+]
+
+[[package]]
+name = "zstd"
+version = "0.13.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fcf2b778a664581e31e389454a7072dab1647606d44f7feea22cd5abb9c9f3f9"
+dependencies = [
+ "zstd-safe",
+]
+
+[[package]]
+name = "zstd-safe"
+version = "7.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "54a3ab4db68cea366acc5c897c7b4d4d1b8994a9cd6e6f841f8964566a419059"
+dependencies = [
+ "zstd-sys",
+]
+
+[[package]]
+name = "zstd-sys"
+version = "2.0.13+zstd.1.5.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "38ff0f21cfee8f97d94cef41359e0c89aa6113028ab0291aa8ca0038995a95aa"
+dependencies = [
+ "cc",
+ "pkg-config",
 ]

--- a/sindri-rs/Cargo.toml
+++ b/sindri-rs/Cargo.toml
@@ -13,7 +13,7 @@ ignore = "0.4.23"
 openapi = { path = "../openapi" }
 rand = "0.8.5"
 regex = "1.11.1"
-reqwest = { version = "0.12.9", features = ["json", "multipart", "zstd"]}
+reqwest = { version = "0.12.9", features = ["json", "multipart", "stream", "zstd"]}
 reqwest-middleware = "0.3.0"
 reqwest-retry = { version = "0.7.0", features = ["tracing"] }
 serde_json = "^1.0"

--- a/sindri-rs/Cargo.toml
+++ b/sindri-rs/Cargo.toml
@@ -4,6 +4,7 @@ version = "0.1.0"
 edition = "2021"
 
 [dependencies]
+async-compression = { version = "0.4.18", features = ["tokio", "zstd"] }
 async-trait = "0.1.83"
 base64 = "0.22.1"
 flate2 = "1.0.35"
@@ -12,7 +13,7 @@ ignore = "0.4.23"
 openapi = { path = "../openapi" }
 rand = "0.8.5"
 regex = "1.11.1"
-reqwest = { version = "0.12.9", features = ["json", "multipart"]}
+reqwest = { version = "0.12.9", features = ["json", "multipart", "zstd"]}
 reqwest-middleware = "0.3.0"
 reqwest-retry = { version = "0.7.0", features = ["tracing"] }
 serde_json = "^1.0"
@@ -20,6 +21,7 @@ tar = "0.4.43"
 tracing = "0.1.41"
 tracing-subscriber = "0.3"
 tokio = { version = "1.42.0", features = ["full"] }
+tokio-util = { version = "0.7.13", features = ["io"] }
 
 # Optional dependencies
 console = { version = "0.15.10", optional = true }

--- a/sindri-rs/src/custom_middleware.rs
+++ b/sindri-rs/src/custom_middleware.rs
@@ -269,7 +269,10 @@ mod tests {
 
     use std::time::{Duration, Instant};
 
+    use async_compression::tokio::bufread::ZstdDecoder;
     use reqwest::header::{HeaderMap, HeaderValue};
+    use tokio::io::AsyncReadExt;
+    use tokio_util::io::StreamReader;
     use wiremock::{
         matchers::{header, method},
         Mock, MockServer, ResponseTemplate,
@@ -407,7 +410,11 @@ mod tests {
         let received_request = mock_server.received_requests().await.unwrap();
         assert_eq!(received_request.len(), 1);
         let compressed_body = &received_request[0].body;
-        let decompressed_body = zstd::decode_all(&compressed_body[..]).unwrap();
+        let mut decoder = ZstdDecoder::new(StreamReader::new(tokio::io::duplex(1024).1));
+        decoder.get_mut().write_all(compressed_body).await.unwrap();
+        decoder.get_mut().shutdown().await.unwrap();
+        let mut decompressed_body = Vec::new();
+        decoder.read_to_end(&mut decompressed_body).await.unwrap();
         assert_eq!(
             decompressed_body,
             original_body.as_bytes(),

--- a/sindri-rs/src/custom_middleware.rs
+++ b/sindri-rs/src/custom_middleware.rs
@@ -6,16 +6,14 @@
 //! - `LoggingMiddleware`: Logs requests and responses.
 //! - `Retry500`: Implements a retry policy for 500-series errors.
 //! - `VCRMiddleware`: Records and replays requests for (internal) testing purposes.
+//! - `ZstdRequestCompressionMiddleware`: Compresses request bodies using zstd.
 
-use std::{collections::HashSet, time::Duration, Arc};
+use std::{collections::HashSet, sync::Arc, time::Duration};
 
 use async_compression::tokio::write::ZstdEncoder;
 use async_trait::async_trait;
 use http::Extensions;
-use reqwest::{
-    header::HeaderValue, header::CONTENT_ENCODING, Body, Request, Request, Response, Response,
-    StatusCode,
-};
+use reqwest::{header::HeaderValue, header::CONTENT_ENCODING, Body, Request, Response, StatusCode};
 use reqwest_middleware::{Middleware, Next, Result};
 use reqwest_retry::{
     default_on_request_failure,

--- a/sindri-rs/src/custom_middleware.rs
+++ b/sindri-rs/src/custom_middleware.rs
@@ -272,7 +272,7 @@ mod tests {
 
     use async_compression::tokio::bufread::ZstdDecoder;
     use reqwest::header::{HeaderMap, HeaderValue};
-    use tokio_util::io::StreamReader;
+    use tokio::io::BufReader;
     use wiremock::{
         matchers::{header, method},
         Mock, MockServer, ResponseTemplate,
@@ -414,8 +414,8 @@ mod tests {
 
         // Decompress the body.
         let cursor = Cursor::new(compressed_body.clone());
-        let stream_reader = StreamReader::new(cursor);
-        let mut decoder = ZstdDecoder::new(stream_reader);
+        let buf_reader = BufReader::new(cursor);
+        let mut decoder = ZstdDecoder::new(buf_reader);
         let mut decompressed_body = Vec::new();
         decoder.read_to_end(&mut decompressed_body).await.unwrap();
 

--- a/sindri-rs/src/custom_middleware.rs
+++ b/sindri-rs/src/custom_middleware.rs
@@ -216,7 +216,7 @@ impl Middleware for ZstdRequestCompressionMiddleware {
         req: Request,
         extensions: &mut Extensions,
         next: Next<'_>,
-    ) -> Result<Response> {
+    ) -> reqwest_middleware::Result<Response> {
         // If the request has a sizable body, compress it using zstd.
         if let Some(bytes) = req
             .body()

--- a/sindri-rs/src/custom_middleware.rs
+++ b/sindri-rs/src/custom_middleware.rs
@@ -206,6 +206,11 @@ pub fn vcr_middleware(bundle: std::path::PathBuf) -> VCRMiddleware {
     vcr
 }
 
+/// Middleware for request and response compression handling.
+///
+/// This implementation compresses request bodies as a stream if the body size
+/// is at least `ZSTD_MIN_BODY_SIZE` and decompresses response bodies if the
+/// `Content-Encoding: zstd` header is present.
 #[derive(Debug)]
 pub struct ZstdRequestCompressionMiddleware;
 

--- a/sindri-rs/src/custom_middleware.rs
+++ b/sindri-rs/src/custom_middleware.rs
@@ -272,6 +272,7 @@ mod tests {
 
     use async_compression::tokio::bufread::ZstdDecoder;
     use reqwest::header::{HeaderMap, HeaderValue};
+    use tokio::io::AsyncReadExt;
     use tokio::io::BufReader;
     use wiremock::{
         matchers::{header, method},
@@ -380,11 +381,10 @@ mod tests {
 
     #[tokio::test]
     async fn test_zstd_request_compression() {
-        let mock_server = MockServer::start().await;
-
         let original_body = "A".repeat(ZSTD_MIN_BODY_SIZE);
 
-        let mock = Mock::given(method("POST"))
+        let mock_server = MockServer::start().await;
+        let _mock = Mock::given(method("POST"))
             .and(header("Content-Encoding", "zstd"))
             .respond_with(ResponseTemplate::new(200))
             .expect(1)

--- a/sindri-rs/src/custom_middleware.rs
+++ b/sindri-rs/src/custom_middleware.rs
@@ -14,7 +14,7 @@ use async_compression::tokio::write::ZstdEncoder;
 use async_trait::async_trait;
 use http::Extensions;
 use reqwest::{header::HeaderValue, header::CONTENT_ENCODING, Body, Request, Response, StatusCode};
-use reqwest_middleware::{Middleware, Next, Result};
+use reqwest_middleware::{Middleware, Next};
 use reqwest_retry::{
     default_on_request_failure,
     policies::{ExponentialBackoff, ExponentialBackoffTimed},


### PR DESCRIPTION
On the response side, this adds the `zstd` feature for the `reqwest` crate which automatically attaches an `Accept-Encoding: zstd` header to outgoing requests and decompresses responses with `Content-Encoding: zstd` headers. The request side was slightly trickier because there isn't built in support in `reqwest`. I implemented the compression here as a new `ZstdRequestCompressionMiddleware` which compresses request bodies as a stream if the body size is at least 512 bytes (a similar minimum size applies in our backend). I went with this approach because it's compatible with our request retry strategy and doesn't add extra request time by blocking on the compression.

Connects Sindri-Labs/sindri-scroll-sdk#33
