### PR TITLE
Add top level directory for cwd projects

### DIFF
--- a/sindri/src/utils.rs
+++ b/sindri/src/utils.rs
@@ -97,7 +97,11 @@ pub async fn compress_directory(
         for entry in walker.filter_map(Result::ok) {
             let path = entry.path();
             if path.is_file() {
-                let relative_path = path.strip_prefix(dir.parent().unwrap())?;
+                let relative_path = if dir == Path::new(".") {
+                    Path::new("project").join(path.strip_prefix(dir)?)
+                } else {
+                    path.strip_prefix(dir.parent().unwrap())?.to_path_buf()
+                };
                 tar.append_file(relative_path, &mut std::fs::File::open(path)?)?;
             }
         }


### PR DESCRIPTION
### 🔄 Pull Request

#### 📝 Description

The `compress_directory` function needs to prepare a tarball with a single top level directory with all project files inside of it (`sindri.json` sitting directly inside that top level folder, etc.).  When `dir` is an arbitrary input path:
```
                let relative_path = path.strip_prefix(dir.parent().unwrap())?;
```
was meant to satisfy this nesting requirement. However it was discovered after using the CLI that when `dir` is the current working directory, there is no parent that we can grab the top level from.  This corner case is fixed by prepending an arbitrary top level:
```
                if dir == Path::new(".") {
                    Path::new("project").join(path.strip_prefix(dir)?)
                ...
```

#### 🔗 Related Tickets & Documents

- Related Issue #
- Closes #

#### 📋 Type of PR (check all applicable)

- [ ] 🔨 Refactor
- [ ] ✨ Feature
- [x] 🐛 Bug Fix
- [ ] ⚡ Optimization
- [ ] 📚 Documentation Update

#### 💭 Developer Notes

Add any additional notes or context for reviewers.

#### 🧪 Testing Instructions

One way the fix was verified live:
```
cd cli/tests/factory
tar -tzvf circuit.tar.gz
cd sample_circuit
cargo sindri deploy .
```

#### ✅ Testing Status
- [x] Yes, tests added/updated
- [ ] No tests needed because: _please explain why_
- [ ] Help needed with testing
