### PR TITLE
Create vendor copy of `rvcr`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5294,27 +5294,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "rvcr"
-version = "0.2.1"
-source = "git+https://github.com/lededje/rvcr?branch=update-reqwest-middleware#74a2e4728067da301eab8d2c00924f61db835245"
-dependencies = [
- "anyhow",
- "async-trait",
- "base64 0.21.7",
- "bytes",
- "chrono",
- "http 1.2.0",
- "lazy_static",
- "reqwest 0.12.9",
- "reqwest-middleware",
- "serde",
- "serde_json",
- "task-local-extensions",
- "tracing",
- "vcr-cassette",
-]
-
-[[package]]
 name = "ryu"
 version = "1.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5703,21 +5682,23 @@ dependencies = [
 name = "sindri"
 version = "0.2.0"
 dependencies = [
+ "anyhow",
  "async-compression",
  "async-trait",
  "base64 0.22.1",
+ "chrono",
  "console",
  "flate2",
  "http 1.2.0",
  "ignore",
  "indicatif",
+ "lazy_static",
  "rand",
  "regex",
  "reqwest 0.12.9",
  "reqwest-middleware",
  "reqwest-retry",
  "rmp-serde",
- "rvcr",
  "serde_json",
  "sindri-openapi",
  "sp1-sdk 3.0.0",
@@ -5730,6 +5711,7 @@ dependencies = [
  "tracing",
  "tracing-subscriber",
  "tracing-test",
+ "vcr-cassette",
  "wiremock",
 ]
 
@@ -6845,15 +6827,6 @@ dependencies = [
  "filetime",
  "libc",
  "xattr",
-]
-
-[[package]]
-name = "task-local-extensions"
-version = "0.1.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ba323866e5d033818e3240feeb9f7db2c4296674e4d9e16b97b7bf8f490434e8"
-dependencies = [
- "pin-utils",
 ]
 
 [[package]]

--- a/sindri/Cargo.toml
+++ b/sindri/Cargo.toml
@@ -28,8 +28,10 @@ console = { version = "0.15.10", optional = true }
 indicatif = { version = "0.17.10", optional = true }
 
 # Integration test dependencies
-# fork that supports newer reqwest-middleware (see https://github.com/ChorusOne/rvcr/pull/22)
-rvcr = { git = "https://github.com/lededje/rvcr", branch = "update-reqwest-middleware", optional = true }
+anyhow = { version = "^1", optional = true }
+chrono = { version = "0.4", features = ["serde"], optional = true }
+lazy_static = { version = "1.4", optional = true }
+vcr-cassette = { version = "2", optional = true}
 
 # Framework-specific dependencies
 rmp-serde = { version = "1.3.0", optional = true }
@@ -46,8 +48,9 @@ wiremock = "0.6.2"
 default = []
 
 # Record and replay middleware, for internal testing
-record = ["dep:rvcr"]
-replay = ["dep:rvcr"]
+record = ["dep:anyhow", "dep:chrono", "dep:lazy_static", "dep:vcr-cassette"]
+replay = ["dep:anyhow", "dep:chrono", "dep:lazy_static", "dep:vcr-cassette"]
+compress = []
 
 # CLI-specific features
 rich-terminal = ["dep:console", "dep:indicatif"]

--- a/sindri/src/custom_middleware.rs
+++ b/sindri/src/custom_middleware.rs
@@ -10,6 +10,8 @@
 
 use std::{collections::HashSet, sync::Arc, time::Duration};
 
+#[cfg(any(feature = "record", feature = "replay"))]
+use crate::vendor::rvcr::{VCRMiddleware, VCRMode};
 use async_compression::tokio::write::ZstdEncoder;
 use async_trait::async_trait;
 use http::Extensions;
@@ -20,8 +22,6 @@ use reqwest_retry::{
     policies::{ExponentialBackoff, ExponentialBackoffTimed},
     RetryTransientMiddleware, Retryable, RetryableStrategy,
 };
-#[cfg(any(feature = "record", feature = "replay"))]
-use crate::vendor::rvcr::{VCRMiddleware, VCRMode};
 #[cfg(any(feature = "record", feature = "replay"))]
 use tokio::io::AsyncReadExt;
 use tokio::io::AsyncWriteExt;

--- a/sindri/src/custom_middleware.rs
+++ b/sindri/src/custom_middleware.rs
@@ -21,7 +21,7 @@ use reqwest_retry::{
     RetryTransientMiddleware, Retryable, RetryableStrategy,
 };
 #[cfg(any(feature = "record", feature = "replay"))]
-use rvcr::{VCRMiddleware, VCRMode};
+use crate::vendor::rvcr::{VCRMiddleware, VCRMode};
 #[cfg(any(feature = "record", feature = "replay"))]
 use tokio::io::AsyncReadExt;
 use tokio::io::AsyncWriteExt;

--- a/sindri/src/lib.rs
+++ b/sindri/src/lib.rs
@@ -47,3 +47,8 @@ pub(crate) mod utils;
 pub mod integrations;
 mod types;
 pub use types::*;
+
+pub mod vendor {
+    #[cfg(any(feature = "record", feature = "replay"))]
+    pub mod rvcr;
+}

--- a/sindri/src/vendor/rvcr/LICENSE
+++ b/sindri/src/vendor/rvcr/LICENSE
@@ -1,0 +1,176 @@
+                                Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS

--- a/sindri/src/vendor/rvcr/NOTICE
+++ b/sindri/src/vendor/rvcr/NOTICE
@@ -1,0 +1,4 @@
+This code is derived from the rvcr crate (https://github.com/ChorusOne/rvcr)
+Copyright 2023 Chorus One AG
+
+Licensed under the Apache License, Version 2.0

--- a/sindri/src/vendor/rvcr/README.md
+++ b/sindri/src/vendor/rvcr/README.md
@@ -1,0 +1,4 @@
+# Vendored VCR Implementation
+
+This is an internal copy of the VCR implementation originally from the [rvcr](https://github.com/ChorusOne/rvcr) crate.
+It has been vendored to maintain better control over dependencies and upgrade cycles.

--- a/sindri/src/vendor/rvcr/mod.rs
+++ b/sindri/src/vendor/rvcr/mod.rs
@@ -396,7 +396,7 @@ impl Middleware for VCRMiddleware {
     async fn handle(
         &self,
         req: reqwest::Request,
-        extensions: &mut task_local_extensions::Extensions,
+        extensions: &mut http::Extensions,
         next: reqwest_middleware::Next<'_>,
     ) -> reqwest_middleware::Result<reqwest::Response> {
         let vcr_request = self.request_to_vcr(req.try_clone().unwrap());

--- a/sindri/src/vendor/rvcr/mod.rs
+++ b/sindri/src/vendor/rvcr/mod.rs
@@ -1,0 +1,545 @@
+//! Record-and-replay middleware for reqwest http client.
+//!
+//! Inspired by [https://github.com/vcr/vcr](Ruby-VCR) and
+//! [https://git.sr.ht/~rjframe/surf-vcr](Surf-VCR) Rust client.
+//!
+//! # Examples
+//!
+//! To record the requests, initialize client like following
+//! ```rust
+//!         use std::path::PathBuf;
+//!         use reqwest::Client;
+//!         use reqwest_middleware::{ClientBuilder, ClientWithMiddleware};
+//!         use rvcr::{VCRMiddleware, VCRMode};
+//!
+//!         let mut bundle = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
+//!         bundle.push("tests/resources/replay.vcr.json");
+//!
+//!         let middleware: VCRMiddleware = VCRMiddleware::try_from(bundle.clone())
+//!             .unwrap()
+//!             .with_mode(VCRMode::Record);
+//!
+//!         let vcr_client: ClientWithMiddleware = ClientBuilder::new(reqwest::Client::new())
+//!             .with(middleware)
+//!             .build();
+//! ```
+//!
+//! To use recorded VCR cassette files, replace `.with_mode(VCRMode::Record)`
+//!  with `.with_mode(VCRMode::Replay)`
+#[cfg(feature = "compress")]
+use std::io::Read;
+#[cfg(feature = "compress")]
+use std::io::Write;
+use std::{fs, path::PathBuf, str::FromStr, sync::Mutex};
+
+use base64::{engine::general_purpose, Engine};
+use reqwest_middleware::Middleware;
+use vcr_cassette::{HttpInteraction, RecorderId};
+
+pub const VERSION: &str = env!("CARGO_PKG_VERSION");
+
+lazy_static::lazy_static! {
+    static ref RECORDER: RecorderId = format!("rVCR {VERSION}");
+    static ref BASE64: String = String::from("base64");
+}
+
+/// Pluggable VCR middleware for record-and-replay for reqwest items
+pub struct VCRMiddleware {
+    path: Option<PathBuf>,
+    storage: Mutex<vcr_cassette::Cassette>,
+    mode: VCRMode,
+    search: VCRReplaySearch,
+    skip: Mutex<usize>,
+    compress: bool,
+    rich_diff: bool,
+    modify_request: Option<Box<RequestModifier>>,
+    modify_response: Option<Box<ResponseModifier>>,
+}
+
+type RequestModifier = dyn Fn(&mut vcr_cassette::Request) + Send + Sync + 'static;
+type ResponseModifier = dyn Fn(&mut vcr_cassette::Response) + Send + Sync + 'static;
+
+/// VCR mode switcher
+#[derive(Eq, PartialEq, Clone)]
+pub enum VCRMode {
+    /// Record requests to the local VCR cassette files. Existing files will be overwritten
+    Record,
+    /// Replay requests using local files
+    Replay,
+}
+
+/// Skip requests
+#[derive(Eq, PartialEq)]
+pub enum VCRReplaySearch {
+    /// Skip requests which already have been found. Useful for
+    /// verifying use-cases with strict request order.
+    SkipFound,
+    /// Search through all requests every time
+    SearchAll,
+}
+
+pub type VCRError = &'static str;
+
+/// Implements boilerplate for converting between vcr_cassette
+/// and reqwest structures.
+///
+/// Carries methods to find response in a cassette, and to record
+/// an interaction.
+impl VCRMiddleware {
+    /// Adjust mode in the middleware and return it
+    pub fn with_mode(mut self, mode: VCRMode) -> Self {
+        self.mode = mode;
+        self
+    }
+
+    pub fn with_modify_request<F>(mut self, modifier: F) -> Self
+    where
+        F: Fn(&mut vcr_cassette::Request) + Send + Sync + 'static,
+    {
+        self.modify_request.replace(Box::new(modifier));
+        self
+    }
+
+    pub fn with_modify_response<F>(mut self, modifier: F) -> Self
+    where
+        F: Fn(&mut vcr_cassette::Response) + Send + Sync + 'static,
+    {
+        self.modify_response.replace(Box::new(modifier));
+        self
+    }
+
+    /// Adjust search behavior for responses
+    pub fn with_search(mut self, search: VCRReplaySearch) -> Self {
+        self.search = search;
+        self
+    }
+
+    /// Adjust path in the middleware and return it
+    pub fn with_path(mut self, path: impl Into<PathBuf>) -> Self {
+        self.path = Some(path.into());
+        self
+    }
+
+    /// Adjust rich diff in the middleware and return it
+    pub fn with_rich_diff(mut self, rich_diff: bool) -> Self {
+        self.rich_diff = rich_diff;
+        self
+    }
+
+    /// Make VCR files to be compressed before creating
+    #[cfg(feature = "compress")]
+    pub fn compressed(mut self, compress: bool) -> Self {
+        self.compress = compress;
+        self
+    }
+
+    fn convert_version_to_vcr(&self, version: http::Version) -> vcr_cassette::Version {
+        if version == http::Version::HTTP_10 {
+            vcr_cassette::Version::Http1_0
+        } else if version == http::Version::HTTP_11 {
+            vcr_cassette::Version::Http1_1
+        } else if version == http::Version::HTTP_2 {
+            vcr_cassette::Version::Http2_0
+        } else {
+            panic!("rVCR only supports http 1.0, 1.1 and 2.0")
+        }
+    }
+
+    fn convert_version_from_vcr(&self, version: vcr_cassette::Version) -> http::Version {
+        match version {
+            vcr_cassette::Version::Http1_0 => http::Version::HTTP_10,
+            vcr_cassette::Version::Http1_1 => http::Version::HTTP_11,
+            vcr_cassette::Version::Http2_0 => http::Version::HTTP_2,
+            _ => {
+                panic!("rVCR only supports http 1.0, 1.1 and 2.0")
+            }
+        }
+    }
+
+    fn bytes_to_vcr_body(&self, body_bytes: &[u8]) -> vcr_cassette::Body {
+        // Try to parse UTF-8 string from the body;
+        // if it fails, body bytes are base64 encoded before saving
+
+        // FIXME: detecting support more encodings
+        match String::from_utf8(body_bytes.to_vec()) {
+            Ok(body_str) => vcr_cassette::Body::from_str(&body_str).unwrap(),
+            Err(e) => {
+                tracing::debug!("Can not deserialize utf-8 string: {e:?}");
+                let base64_str = general_purpose::STANDARD_NO_PAD.encode(body_bytes);
+                vcr_cassette::Body {
+                    string: base64_str,
+                    encoding: Some(BASE64.to_string()),
+                }
+            }
+        }
+    }
+
+    fn headers_to_vcr(&self, headers: &reqwest::header::HeaderMap) -> vcr_cassette::Headers {
+        let mut vcr_headers = vcr_cassette::Headers::new();
+        for (header_name, header_value) in headers {
+            let header_name_string = header_name.to_string();
+            let header_value_bytes = header_value.as_bytes();
+            let header_value = String::from_utf8(header_value_bytes.to_vec())
+                .unwrap_or_else(|_| panic!("Non utf header value for header named {header_name}; header values are supposed to be ASCII encoded"));
+            vcr_headers.insert(header_name_string, vec![header_value]);
+        }
+        vcr_headers
+    }
+
+    fn request_to_vcr(&self, req: reqwest::Request) -> vcr_cassette::Request {
+        let body = match req.body() {
+            Some(body) => match body.as_bytes() {
+                Some(body_bytes) => self.bytes_to_vcr_body(body_bytes),
+                None => vcr_cassette::Body::from_str("").unwrap(),
+            },
+            None => vcr_cassette::Body::from_str("").unwrap(),
+        };
+
+        let method_str = req.method().to_string().to_lowercase();
+
+        let method: vcr_cassette::Method = serde_json::from_str(&format!("\"{method_str}\""))
+            .unwrap_or_else(|_| panic!("Unknown HTTP method passed from reqwest: {method_str}"));
+
+        let headers = self.headers_to_vcr(req.headers());
+
+        let mut vcr_request = vcr_cassette::Request {
+            body,
+            method,
+            uri: req.url().to_owned(),
+            headers,
+        };
+
+        if let Some(ref modifier) = self.modify_request {
+            modifier(&mut vcr_request);
+        }
+
+        vcr_request
+    }
+
+    async fn response_to_vcr(&self, resp: reqwest::Response) -> vcr_cassette::Response {
+        let http_version = Some(self.convert_version_to_vcr(resp.version()));
+        let status_code = resp.status();
+        let headers = self.headers_to_vcr(resp.headers());
+        let response_text = resp.bytes().await.expect("Can not fetch response bytes");
+        let body = self.bytes_to_vcr_body(&response_text);
+
+        let status = vcr_cassette::Status {
+            code: status_code.as_u16(),
+            message: status_code
+                .canonical_reason()
+                .unwrap_or("Unknown")
+                .to_string(),
+        };
+
+        let mut vcr_response = vcr_cassette::Response {
+            body,
+            http_version,
+            status,
+            headers,
+        };
+
+        if let Some(ref modifier) = self.modify_response {
+            modifier(&mut vcr_response);
+        }
+
+        vcr_response
+    }
+
+    fn header_values_to_string(&self, header_values: Option<&Vec<String>>) -> String {
+        match header_values {
+            Some(values) => values.join(", "),
+            None => "<MISSING>".to_string(),
+        }
+    }
+
+    fn find_response_in_vcr(&self, req: vcr_cassette::Request) -> Option<vcr_cassette::Response> {
+        let cassette = self.storage.lock().unwrap();
+        let iteractions: Vec<&HttpInteraction> = match self.search {
+            VCRReplaySearch::SkipFound => {
+                let skip = *self.skip.lock().unwrap();
+                *self.skip.lock().unwrap() += 1;
+                cassette.http_interactions.iter().skip(skip).collect()
+            }
+            VCRReplaySearch::SearchAll => cassette.http_interactions.iter().collect(),
+        };
+
+        // we only want to log match failures if no match is found, so capture
+        // everything at the beginning and then output it all at once if none
+        // are found
+        let mut diff_log = if self.rich_diff {
+            Some(String::new())
+        } else {
+            None
+        };
+        for interaction in iteractions {
+            if interaction.request == req {
+                return Some(interaction.response.clone());
+            }
+            if let Some(diff) = diff_log.as_mut() {
+                diff.push_str(&format!(
+                    "Did not match {method:?} to {uri}:\n",
+                    method = interaction.request.method,
+                    uri = interaction.request.uri.as_str()
+                ));
+                if interaction.request.method != req.method {
+                    diff.push_str(&format!(
+                        "  Method differs: recorded {expected:?}, got {got:?}\n",
+                        expected = interaction.request.method,
+                        got = req.method
+                    ));
+                }
+                if interaction.request.uri != req.uri {
+                    diff.push_str("  URI differs:\n");
+                    diff.push_str(&format!(
+                        "    recorded: \"{}\"\n",
+                        interaction.request.uri.as_str()
+                    ));
+                    diff.push_str(&format!("    got:      \"{}\"\n", req.uri.as_str()));
+                }
+                if interaction.request.headers != req.headers {
+                    diff.push_str("  Headers differ:\n");
+                    for (recorded_header_name, recorded_header_values) in
+                        &interaction.request.headers
+                    {
+                        let expected = self.header_values_to_string(Some(recorded_header_values));
+                        let got =
+                            self.header_values_to_string(req.headers.get(recorded_header_name));
+                        if expected != got {
+                            diff.push_str(&format!("    {}:\n", recorded_header_name));
+                            diff.push_str(&format!("      recorded: \"{}\"\n", expected));
+                            diff.push_str(&format!("      got:      \"{}\"\n", got));
+                        }
+                    }
+                    for (got_header_name, got_header_values) in &req.headers {
+                        if !interaction.request.headers.contains_key(got_header_name) {
+                            let got = self.header_values_to_string(Some(got_header_values));
+                            diff.push_str(&format!("    {}:\n", got_header_name));
+                            diff.push_str("      recorded: <MISSING>\n");
+                            diff.push_str(&format!("      got:      \"{}\"\n", got));
+                        }
+                    }
+                }
+                if interaction.request.body != req.body {
+                    diff.push_str("  Body differs:\n");
+                    diff.push_str(&format!(
+                        "    recorded: \"{}\"\n",
+                        interaction.request.body.string
+                    ));
+                    diff.push_str(&format!("    got:      \"{}\"\n", req.body.string));
+                }
+                diff.push('\n');
+            }
+        }
+        if let Some(diff) = diff_log {
+            // tracing_test does not appear to capture multiline outputs for test
+            // assertion purposes, so we print each line out separately
+            for line in diff.split('\n') {
+                tracing::info!("{}", line);
+            }
+        }
+        None
+    }
+
+    fn vcr_to_response(&self, response: vcr_cassette::Response) -> reqwest::Response {
+        let code = response.status.code;
+        let mut builder = http::Response::builder().status(code);
+        for (header_name, header_values) in response.headers {
+            builder = builder.header(header_name, header_values.first().unwrap());
+        }
+        let http_version = self.convert_version_from_vcr(
+            response
+                .http_version
+                .unwrap_or(vcr_cassette::Version::Http1_1),
+        );
+        let builder = builder.version(http_version);
+
+        match response.body.encoding {
+            None => {
+                if !response.body.string.is_empty() {
+                    reqwest::Response::from(builder.body(response.body.string).unwrap())
+                } else {
+                    reqwest::Response::from(builder.body("".as_bytes()).unwrap())
+                }
+            }
+            Some(encoding) => {
+                if encoding == "base64" {
+                    let decoded = general_purpose::STANDARD_NO_PAD
+                        .decode(encoding)
+                        .expect("Invalid response body base64 can not be decoded");
+                    reqwest::Response::from(builder.body(decoded).unwrap())
+                } else {
+                    // FIXME: support more encodings
+                    panic!("Unsupported encoding: {encoding}");
+                }
+            }
+        }
+    }
+
+    fn record(&self, request: vcr_cassette::Request, response: vcr_cassette::Response) {
+        let mut cassette = self.storage.lock().unwrap();
+        cassette
+            .http_interactions
+            .push(vcr_cassette::HttpInteraction {
+                response,
+                request,
+                recorded_at: chrono::Utc::now().into(),
+            });
+    }
+}
+
+/// Reqwest middleware implementation
+///
+/// It receives request, converts it to internal VCR format,
+/// and saves data in the internal.
+#[async_trait::async_trait]
+impl Middleware for VCRMiddleware {
+    async fn handle(
+        &self,
+        req: reqwest::Request,
+        extensions: &mut task_local_extensions::Extensions,
+        next: reqwest_middleware::Next<'_>,
+    ) -> reqwest_middleware::Result<reqwest::Response> {
+        let vcr_request = self.request_to_vcr(req.try_clone().unwrap());
+
+        match self.mode {
+            VCRMode::Record => {
+                let response = next.run(req, extensions).await?;
+                let vcr_response = self.response_to_vcr(response).await;
+                let converted_response = self.vcr_to_response(vcr_response.clone());
+                self.record(vcr_request, vcr_response);
+                Ok(converted_response)
+            }
+            VCRMode::Replay => match self.find_response_in_vcr(vcr_request) {
+                None => {
+                    let message = format!(
+                        "Cannot find corresponding request in cassette {:?}",
+                        self.path,
+                    );
+                    Err(reqwest_middleware::Error::Middleware(anyhow::anyhow!(
+                        message
+                    )))
+                }
+                Some(response) => {
+                    let response = self.vcr_to_response(response);
+                    Ok(response)
+                }
+            },
+        }
+    }
+}
+
+/// Create middleware instance from Cassette
+impl From<vcr_cassette::Cassette> for VCRMiddleware {
+    fn from(cassette: vcr_cassette::Cassette) -> Self {
+        VCRMiddleware {
+            storage: Mutex::new(cassette),
+            mode: VCRMode::Replay,
+            path: None,
+            skip: Mutex::new(0),
+            search: VCRReplaySearch::SkipFound,
+            compress: false,
+            rich_diff: false,
+            modify_request: None,
+            modify_response: None,
+        }
+    }
+}
+
+/// Save cassette interactions after the run
+impl Drop for VCRMiddleware {
+    fn drop(&mut self) {
+        if self.mode == VCRMode::Record {
+            let path = self
+                .path
+                .clone()
+                .unwrap_or(format!(".rvcr-{}.vcr", chrono::Utc::now().timestamp()).into());
+            let cassette = self.storage.lock().unwrap();
+
+            let contents: String = serde_json::to_string_pretty(&*cassette).unwrap();
+
+            #[cfg(feature = "compress")]
+            if self.compress {
+                let file = std::fs::File::create(path.clone()).unwrap();
+
+                let mut zip = zip::ZipWriter::new(file);
+
+                let options = zip::write::FileOptions::default()
+                    .compression_method(zip::CompressionMethod::Bzip2)
+                    .compression_level(Some(9))
+                    .unix_permissions(0o644);
+                zip.start_file("test.vcr.json", options).unwrap();
+                zip.write_all(contents.as_bytes()).unwrap();
+                zip.finish().unwrap();
+            }
+
+            if !self.compress {
+                fs::write(path.clone(), contents.as_bytes())
+                    .unwrap_or_else(|_| panic!("Can not write cassette contents to {path:?}"));
+                tracing::info!("Written VCR cassette file at {path:?}");
+            }
+        }
+    }
+}
+
+/// Load VCR cassette for filesystem
+//
+/// For simplicity, support JSON format only for now
+impl TryFrom<PathBuf> for VCRMiddleware {
+    fn try_from(pb: PathBuf) -> Result<Self, Self::Error> {
+        let empty = vcr_cassette::Cassette {
+            http_interactions: vec![],
+            recorded_with: RECORDER.to_string(),
+        };
+
+        let mut mw = Self::from(empty);
+        mw.path = Some(pb.clone());
+        if !pb.exists() {
+            Ok(mw)
+        } else {
+            let content = fs::read(pb.clone()).map_err(|e| {
+                tracing::error!("Failed reading VCR cassette: {e}");
+                format!(
+                    "Failed to read VCR cassette from path {}",
+                    pb.to_str().unwrap()
+                )
+            })?;
+
+            #[cfg(feature = "compress")]
+            let content = {
+                let file = fs::File::open(mw.path.clone().unwrap()).unwrap();
+                match zip::ZipArchive::new(file) {
+                    Ok(mut archive) => {
+                        let mut content = content;
+                        content.clear();
+                        let contents = archive.by_name("test.vcr.json");
+                        let mut contents =
+                            contents.expect("test.vcr.json file is missing in zip archive");
+                        contents
+                            .read_to_end(&mut content)
+                            .expect("Can not read test.vcr.json from zip archive");
+                        content
+                    }
+                    Err(e) => {
+                        tracing::debug!("Failed to detect file as zip: {e:?}");
+                        content
+                    }
+                }
+            };
+
+            let cassette: vcr_cassette::Cassette =
+                serde_json::from_slice(&content).map_err(|e| {
+                    tracing::error!("Failed deserializing VCR cassette: {e}");
+                    format!(
+                        "Failed to deserialize VCR cassette from path {}",
+                        pb.to_str().unwrap()
+                    )
+                })?;
+
+            let mut mw = Self::from(cassette);
+            mw.path = Some(pb);
+            Ok(mw)
+        }
+    }
+
+    type Error = String;
+}


### PR DESCRIPTION
### 🔄 Pull Request

#### 📝 Description

We use [`rvcr`](https://github.com/ChorusOne/rvcr) to record API requests and responses so that general integration tests are faster and cheaper.  Previously we used a github fork of `rvcr` that updated the `reqwest_middleware` package version to 0.3.0.  There are two reasons we decided to move this code inside a vendor module:
1. Desire to publish to crates.io. While we could have probably moved the `record` and `replay` features inside of dev dependencies, it was going to be a nontrivial effort, since those features sabotage the regular unit tests (`wiremock` and `rvcr` cannot easily coexist here)
2. Controlling version upgrades. The `reqwest_middleware` package is now on 0.4.0 and so when we need to upgrade (due to some other package requirements), we will no longer be able to depend on the stale PR upgrading `rvcr`'s dep to 0.3.0.

#### 🔗 Related Tickets & Documents

- Related Issue #
- Closes #

#### 📋 Type of PR (check all applicable)

- [x] 🔨 Refactor
- [ ] ✨ Feature
- [ ] 🐛 Bug Fix
- [ ] ⚡ Optimization
- [ ] 📚 Documentation Update

#### 💭 Developer Notes

We imported the license from this package as well as a clear notice of where the code came from.  While it was tempting to make the upgrade to `reqwest_middleware` 0.4.0 in the same PR, we'll put that off for awhile longer since a few other changes to `custom_middleware.rs` may be required.

#### 🧪 Testing Instructions

Provide clear steps to test the changes. 

#### ✅ Testing Status
- [ ] Yes, tests added/updated
- [x] No tests needed because: the integration tests invoked via `replay` feature will establish that the `rvcr` middleware was ported correctly
- [ ] Help needed with testing
