### PR TITLE
ci: Automate release + publish

### DIFF
--- a/.github/workflows/release-plz.yml
+++ b/.github/workflows/release-plz.yml
@@ -1,0 +1,58 @@
+name: Release-plz
+
+permissions:
+  pull-requests: write
+  contents: write
+
+on:
+  push:
+    branches:
+      - main
+
+jobs:
+
+  # Release unpublished packages.
+  release-plz-release:
+    name: Release-plz release
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - name: Install Rust toolchain
+        uses: dtolnay/rust-toolchain@stable
+      - name: Run release-plz
+        uses: release-plz/action@v0.5
+        with:
+          command: release
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          CARGO_REGISTRY_TOKEN: ${{ secrets.CRATES_TOKEN }}
+
+  # Create a PR with the new versions and changelog, preparing the next release.
+  release-plz-pr:
+    name: Release-plz PR
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: write
+    concurrency:
+      group: release-plz-${{ github.ref }}
+      cancel-in-progress: false
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - name: Install Rust toolchain
+        uses: dtolnay/rust-toolchain@stable
+      - name: Run release-plz
+        uses: release-plz/action@v0.5
+        with:
+          command: release-pr
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          CARGO_REGISTRY_TOKEN: ${{ secrets.CRATES_TOKEN }}

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ version = "0.2.1"
 edition = "2021"
 authors = ["Sindri Labs <support@sindri.app>"]
 homepage = "https://sindri.app/"
-repository = "https://github.com/Sindri-Labs/sindri-rs"
+repository = "https://github.com/Sindri-Labs/sindri-rust"
 license = "MIT"
 keywords = ["sindri", "sdk", "api", "zero-knowledge", "zkvm"]
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Sindri Rust SDK
 
-<img src="https://github.com/Sindri-Labs/sindri-rust/blob/main/.github/assets/sindri-gradient-logo.webp" height="160" align="right"/>
+<img src="https://github.com/Sindri-Labs/sindri-rust/blob/d3cd52fbc1333910557a48ed91a946067e0b44db/.github/assets/sindri-gradient-logo.webp" height="160" align="right"/>
 
 #### [Sindri Sign Up](https://sindri.app/signup) | [Getting Started](https://sindri.app/docs/getting-started/) | [Public Projects](https://sindri.app/explore)
 

--- a/examples/sp1-proof/Cargo.toml
+++ b/examples/sp1-proof/Cargo.toml
@@ -2,6 +2,7 @@
 name = "sp1-proof"
 version = "0.1.0"
 edition = "2021"
+publish = false
 
 [dependencies]
 sindri = { path = "../../sindri", features = ["sp1-v3"] }

--- a/sindri/Cargo.toml
+++ b/sindri/Cargo.toml
@@ -2,6 +2,7 @@
 name = "sindri"
 description = "Rust SDK for the Sindri API"
 readme = "../README.md"
+documentation = "https://docs.rs/sindri"
 version.workspace = true
 edition.workspace = true
 authors.workspace = true


### PR DESCRIPTION
### 🔄 Pull Request

#### 📝 Description

This adds the [release-plz](https://release-plz.dev/docs) action to the repo to automate version bumps and crate publishing.

#### 🔗 Related Tickets & Documents

- Related Issue #
- Closes #

#### 📋 Type of PR (check all applicable)

- [ ] 🔨 Refactor
- [x] ✨ Feature
- [ ] 🐛 Bug Fix
- [ ] ⚡ Optimization
- [ ] 📚 Documentation Update

#### 💭 Developer Notes

While we did consider the more common [release-please](https://github.com/googleapis/release-please) action, this alternative makes a more compelling argument for a slower moving project like this with (1) no special config files and (2) relaxed stance on conventional commits.

After the first initial publish to crates, there were a few permalink issues and missing documentation links that are also addressed.

#### 🧪 Testing Instructions

Provide clear steps to test the changes. 

#### ✅ Testing Status
- [ ] Yes, tests added/updated
- [x] No tests needed because: the bot needs more mileage before we can evaluate it
- [ ] Help needed with testing
