### PR TITLE
feat: `cargo sindri clone`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5723,9 +5723,12 @@ dependencies = [
  "assert_cmd",
  "clap",
  "console",
+ "flate2",
  "predicates",
  "regex",
  "sindri",
+ "tar",
+ "tempfile",
  "tokio",
  "wiremock",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5730,6 +5730,7 @@ dependencies = [
  "tar",
  "tempfile",
  "tokio",
+ "urlencoding",
  "wiremock",
 ]
 
@@ -7423,6 +7424,12 @@ dependencies = [
  "percent-encoding",
  "serde",
 ]
+
+[[package]]
+name = "urlencoding"
+version = "2.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "daf8dba3b7eb870caf1ddeed7bc9d2a049f3cfdfae7cb521b087cc33ae4c49da"
 
 [[package]]
 name = "utf8parse"

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -16,12 +16,15 @@ name="cargo-sindri"
 [dependencies]
 clap = { version = "4.0", features = ["derive"] }
 console = "0.15.10"
+flate2 = "1.0.35"
 regex = "1.11.1"
 sindri = { workspace = true }
+tar = "0.4.43"
 
 [dev-dependencies]
 assert_cmd = "2.0.16"
 predicates = "3.1.3"
+tempfile = "3.2"
 tokio = { version = "1.0", features = ["full"] }
 wiremock = "0.6.2"
 

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -26,6 +26,7 @@ assert_cmd = "2.0.16"
 predicates = "3.1.3"
 tempfile = "3.2"
 tokio = { version = "1.0", features = ["full"] }
+urlencoding= "2.1.3"
 wiremock = "0.6.2"
 
 [features]

--- a/cli/README.md
+++ b/cli/README.md
@@ -5,10 +5,10 @@ An alternative Sindri CLI, written in typescript and distributed as a npm packag
 
 ## Installation
 
-Install the CLI directly from this repository via:
+Install the latest Sindri rust CLI via:
 
 ```bash
-cargo install --path cli --locked
+cargo install sindri-cli --force --locked
 ```
 
 ## Usage

--- a/cli/README.md
+++ b/cli/README.md
@@ -13,7 +13,25 @@ cargo install sindri-cli --force --locked
 
 ## Usage
 
+### Clone a Circuit
+
+Retrieve the original source code that was uploaded to Sindri for a given project build via:
+
+```bash
+cargo sindri clone <CIRCUIT> < [OPTIONS]
+```
+
+#### Arguments
+- `<CIRCUIT>`: UUID or project build identifier to clone
+
+#### Options
+- `--directory <DIR>`: Path where the circuit should be saved (defaults to circuit name)
+- `--api-key <KEY>`: Sindri API key (overrides SINDRI_API_KEY env var)
+- `--base-url <URL>`: Sindri API base URL (overrides SINDRI_BASE_URL env var)
+
 ### Deploy a Circuit
+
+Upload your local DSL circuit or zkVM code to Sindri so that you can generate proofs via:
 
 ```bash
 cargo sindri deploy <PATH> [OPTIONS]

--- a/cli/src/bin/cargo-sindri.rs
+++ b/cli/src/bin/cargo-sindri.rs
@@ -48,7 +48,7 @@ pub enum Commands {
     },
 }
 
-fn handle_circuit_error(message: &str) -> ! {
+fn handle_deploy_error(message: &str) -> ! {
     eprintln!("{}", style("Circuit creation failed ❌").bold());
     eprintln!("{}", style(message).red());
     std::process::exit(1);
@@ -85,7 +85,7 @@ fn main() {
                                 parts.next().unwrap_or_default().to_string(),
                             ))
                         } else {
-                            handle_circuit_error(&format!(
+                            handle_deploy_error(&format!(
                                 "\"{pair}\" is not a valid metadata pair."
                             ));
                         }
@@ -123,10 +123,10 @@ fn main() {
                             style(format!("{}/{}:{}", team, project_name, first_tag)).cyan()
                         );
                     } else {
-                        handle_circuit_error(&response.error().unwrap_or_default())
+                        handle_deploy_error(&response.error().unwrap_or_default())
                     }
                 }
-                Err(e) => handle_circuit_error(&e.to_string()),
+                Err(e) => handle_deploy_error(&e.to_string()),
             }
         }
     }

--- a/cli/src/bin/cargo-sindri.rs
+++ b/cli/src/bin/cargo-sindri.rs
@@ -32,6 +32,16 @@ pub struct Cli {
 
 #[derive(Subcommand)]
 pub enum Commands {
+    /// Clone a circuit
+    Clone {
+        /// Circuit ID to clone, could be a UUID or a team/project:tag identifier
+        #[arg(required = true)]
+        circuit: String,
+
+        /// Directory where the circuit should be downloaded
+        #[arg(required = true)]
+        directory: String,
+    },
     /// Deploy a circuit
     Deploy {
         /// Path to circuit project directory or archive
@@ -45,16 +55,6 @@ pub enum Commands {
         /// Optional metadata key-value pairs (format: key=value,key2=value2)
         #[arg(long, value_delimiter = ',')]
         meta: Option<Vec<String>>,
-    },
-    /// Clone a circuit
-    Clone {
-        /// Circuit ID to clone, could be a UUID or a team/project:tag identifier
-        #[arg(required = true)]
-        circuit: String,
-
-        /// Directory where the circuit should be downloaded
-        #[arg(required = true)]
-        directory: String,
     },
 }
 
@@ -75,6 +75,12 @@ fn main() {
     let client = SindriClient::new(Some(auth), None);
 
     match args.command {
+        Commands::Clone { circuit, directory } => {
+            match client.clone_circuit_blocking(&circuit, directory, None) {
+                Ok(_) => println!("Successfully cloned circuit {}", circuit),
+                Err(e) => handle_operation_error("clone", &e.to_string()),
+            }
+        },
         Commands::Deploy {
             project,
             tags,
@@ -137,12 +143,6 @@ fn main() {
                     }
                 }
                 Err(e) => handle_operation_error("deploy", &e.to_string()),
-            }
-        }
-        Commands::Clone { circuit, directory } => {
-            match client.clone_circuit_blocking(&circuit, directory, None) {
-                Ok(_) => println!("Successfully cloned circuit {}", circuit),
-                Err(e) => handle_operation_error("clone", &e.to_string()),
             }
         }
     }

--- a/cli/src/bin/cargo-sindri.rs
+++ b/cli/src/bin/cargo-sindri.rs
@@ -292,7 +292,7 @@ mod tests {
 
         cmd.assert()
             .success()
-            .stdout(predicate::str::contains("Successfully cloned circuit"));
+            .stdout(predicate::str::contains("Circuit downloaded to:"));
 
         // Check that dir_path/sindri.json exists
         let sindri_json_path = dir_path.join("circuit").join("sindri.json");

--- a/sindri/src/client.rs
+++ b/sindri/src/client.rs
@@ -509,8 +509,7 @@ impl SindriClient {
     ///
     /// client.clone_circuit(
     ///     project_build_id,
-    ///     download_path,
-    ///     None
+    ///     download_path
     /// ).await.unwrap();
     /// # });
     /// ```

--- a/sindri/src/client.rs
+++ b/sindri/src/client.rs
@@ -518,28 +518,10 @@ impl SindriClient {
         &self,
         circuit_id: &str,
         download_path: String,
-        override_max_project_size: Option<usize>,
     ) -> Result<(), Box<dyn std::error::Error>> {
         info!("Cloning circuit with ID: {}", circuit_id);
         debug!("Download path: {}", download_path);
-        // Ensure circuit exists, is ready, and is not too large
-        let circuit_info = circuit_detail(&self.config, circuit_id, None).await?;
-        if *circuit_info.status() != JobStatus::Ready {
-            warn!("Circuit does not indicate ready status");
-            return Err("Circuit does not indicate ready status".into());
-        }
-        if circuit_info.file_size().unwrap_or(0) as u64
-            > override_max_project_size.unwrap_or(2 * 1024 * 1024 * 1024) as u64
-        {
-            // 2GB
-            warn!(
-                "Circuit tarball is larger than {} bytes.",
-                override_max_project_size.unwrap_or(2 * 1024 * 1024 * 1024)
-            );
-            return Err(format!("Circuit tarball is larger than {} bytes. If you still want to clone it, pass a larger size into `override_max_project_size`", override_max_project_size.unwrap_or(2* 1024 * 1024 * 1024)).into());
-        }
 
-        // Then, download the circuit
         let download_response = circuit_download(&self.config, circuit_id, None).await?;
         debug!("Circuit downloaded successfully");
         // Write the circuit to the specified path
@@ -557,10 +539,9 @@ impl SindriClient {
         &self,
         circuit_id: &str,
         download_path: String,
-        override_max_project_size: Option<usize>,
     ) -> Result<(), Box<dyn std::error::Error>> {
         let runtime = tokio::runtime::Runtime::new()?;
-        runtime.block_on(self.clone_circuit(circuit_id, download_path, override_max_project_size))
+        runtime.block_on(self.clone_circuit(circuit_id, download_path))
     }
 
     /// Retrieves the details of a circuit.

--- a/sindri/src/client.rs
+++ b/sindri/src/client.rs
@@ -549,6 +549,20 @@ impl SindriClient {
         Ok(())
     }
 
+    /// Blocking version of `clone_circuit`.
+    ///
+    /// This method provides the same functionality as `clone_circuit` but can be used
+    /// in synchronous contexts. It internally creates a runtime to execute the async operation.
+    pub fn clone_circuit_blocking(
+        &self,
+        circuit_id: &str,
+        download_path: String,
+        override_max_project_size: Option<usize>,
+    ) -> Result<(), Box<dyn std::error::Error>> {
+        let runtime = tokio::runtime::Runtime::new()?;
+        runtime.block_on(self.clone_circuit(circuit_id, download_path, override_max_project_size))
+    }
+
     /// Retrieves the details of a circuit.
     ///
     /// You can use this method to get the status, metadata, and other details of a circuit.

--- a/sindri/tests/projects.rs
+++ b/sindri/tests/projects.rs
@@ -131,25 +131,9 @@ async fn test_clone_circuit() {
 
     let clone_temp_dir = TempDir::new().unwrap();
     let clone_file_path = clone_temp_dir.path().join("clone.tar.gz");
-    let mut clone_result = client
-        .clone_circuit(
-            circuit.id(),
-            clone_file_path.to_string_lossy().to_string(),
-            Some(10),
-        )
-        .await;
-    assert!(clone_result.is_err());
-    assert!(clone_result
-        .unwrap_err()
-        .to_string()
-        .contains("tarball is larger than"));
 
-    clone_result = client
-        .clone_circuit(
-            circuit.id(),
-            clone_file_path.to_string_lossy().to_string(),
-            None,
-        )
+    let clone_result = client
+        .clone_circuit(circuit.id(), clone_file_path.to_string_lossy().to_string())
         .await;
     assert!(clone_result.is_ok());
 


### PR DESCRIPTION
### 🔄 Pull Request

#### 📝 Description

This adds a `cargo sindri clone` command mirroring the behavior of the standard [sindri clone](https://sindri.app/docs/reference/cli/clone/). Similar rationale as in #10, some users may prefer the rust toolchain and crates distribution over npm.

#### 🔗 Related Tickets & Documents

- Related Issue #
- Closes #29 

#### 📋 Type of PR (check all applicable)

- [ ] 🔨 Refactor
- [x] ✨ Feature
- [ ] 🐛 Bug Fix
- [ ] ⚡ Optimization
- [ ] 📚 Documentation Update

#### 💭 Developer Notes

Changes to the `sindri` package were made after discovering unexpected behavior from the circuit detail endpoint.  During initial testing, we did not try a circuit owned by an external team. In that case the response is not a `CircuitInfoResponse` type, rather a variant of the `ProjectInfoResponse` type. So we had to remove some of the checks at the beginning of the clone command.

We parse out and validate the circuit name identical to the [TS version].  

#### 🧪 Testing Instructions

Provide clear steps to test the changes. 

#### ✅ Testing Status
- [x] Yes, tests added/updated
- [ ] No tests needed because: _please explain why_
- [ ] Help needed with testing
