### PR TITLE
feat(cli): api key generation

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6059,7 +6059,6 @@ dependencies = [
  "flate2",
  "predicates",
  "regex",
- "serde_json",
  "sindri",
  "sindri-openapi",
  "tar",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6060,7 +6060,6 @@ dependencies = [
  "predicates",
  "regex",
  "sindri",
- "sindri-openapi",
  "tar",
  "tempfile",
  "tokio",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6059,6 +6059,7 @@ dependencies = [
  "flate2",
  "predicates",
  "regex",
+ "serde_json",
  "sindri",
  "sindri-openapi",
  "tar",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1782,6 +1782,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "dialoguer"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "658bce805d770f407bc62102fca7c2c64ceef2fbcb2b8bd19d2765ce093980de"
+dependencies = [
+ "console",
+ "shell-words",
+ "tempfile",
+ "thiserror 1.0.69",
+ "zeroize",
+]
+
+[[package]]
 name = "difflib"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5955,6 +5968,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "shell-words"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "24188a676b6ae68c3b2cb3a01be17fbf7240ce009799bb56d5b1409051e78fde"
+
+[[package]]
 name = "shlex"
 version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6036,10 +6055,12 @@ dependencies = [
  "assert_cmd",
  "clap",
  "console",
+ "dialoguer",
  "flate2",
  "predicates",
  "regex",
  "sindri",
+ "sindri-openapi",
  "tar",
  "tempfile",
  "tokio",

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -19,7 +19,6 @@ console = "0.15.10"
 dialoguer = "0.11.0"
 flate2 = "1.0.35"
 regex = "1.11.1"
-sindri-openapi = { workspace = true }
 sindri = { workspace = true }
 tar = "0.4.43"
 tokio = { version = "1.0", features = ["full"] }

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -30,7 +30,6 @@ predicates = "3.1.3"
 tempfile = "3.2"
 urlencoding= "2.1.3"
 wiremock = "0.6.2"
-serde_json = "1.0"
 
 [features]
 default = ["sindri/rich-terminal"]

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -16,16 +16,18 @@ name="cargo-sindri"
 [dependencies]
 clap = { version = "4.0", features = ["derive"] }
 console = "0.15.10"
+dialoguer = "0.11.0"
 flate2 = "1.0.35"
 regex = "1.11.1"
+sindri-openapi = { workspace = true }
 sindri = { workspace = true }
 tar = "0.4.43"
+tokio = { version = "1.0", features = ["full"] }
 
 [dev-dependencies]
 assert_cmd = "2.0.16"
 predicates = "3.1.3"
 tempfile = "3.2"
-tokio = { version = "1.0", features = ["full"] }
 urlencoding= "2.1.3"
 wiremock = "0.6.2"
 

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -30,6 +30,7 @@ predicates = "3.1.3"
 tempfile = "3.2"
 urlencoding= "2.1.3"
 wiremock = "0.6.2"
+serde_json = "1.0"
 
 [features]
 default = ["sindri/rich-terminal"]

--- a/cli/README.md
+++ b/cli/README.md
@@ -13,6 +13,29 @@ cargo install sindri-cli --force --locked
 
 ## Usage
 
+### Login
+
+Most functionalities within the Sindri Rust SDK and CLI require you to supply your API key.
+This method allows you to create an API key by providing your Sindri username and password via:
+
+```bash
+cargo sindri login [OPTIONS]
+```
+
+#### Options
+- `--username <USERNAME>`: Sindri username (optional, will prompt if not provided)
+- `--password <PASSWORD>`: Sindri password (optional, will prompt if not provided)
+- `--keyname <KEYNAME>`: Name to identify your new key (optional, will prompt if not provided)
+- `--teamname <TEAMNAME>`: Sindri team which the key should be created for (optional, will prompt if not provided)
+- `--base-url <URL>`: Sindri API base URL (overrides SINDRI_BASE_URL env var)
+
+The login command will prompt for your Sindri credentials (if not provided via options) and allow you to select a team to generate an API key for.
+
+After successful login, you can use the generated API key by either:
+- Setting the `SINDRI_API_KEY` environment variable
+- Using the `--api-key` flag with any `cargo sindri` command
+
+
 ### Clone a Circuit
 
 Retrieve the original source code that was uploaded to Sindri for a given project build via:

--- a/cli/src/bin/cargo-sindri.rs
+++ b/cli/src/bin/cargo-sindri.rs
@@ -1,7 +1,7 @@
 use clap::{command, Parser, Subcommand};
 use sindri::client::{AuthOptions, SindriClient};
 
-use sindri_cli::commands::{clone, deploy};
+use sindri_cli::commands::{clone, deploy, login};
 
 #[derive(Parser)]
 #[command(name = "cargo", bin_name = "cargo")]
@@ -50,6 +50,8 @@ pub enum Commands {
         #[arg(long, value_delimiter = ',')]
         meta: Option<Vec<String>>,
     },
+    /// Login to Sindri
+    Login,
 }
 
 fn main() {
@@ -72,6 +74,9 @@ fn main() {
             meta,
         } => {
             deploy(&client, project, tags, meta);
+        }
+        Commands::Login => {
+            login(&client);
         }
     }
 }

--- a/cli/src/bin/cargo-sindri.rs
+++ b/cli/src/bin/cargo-sindri.rs
@@ -1,15 +1,7 @@
-use std::{collections::HashMap, fs, io::Cursor, path::Path};
-
 use clap::{command, Parser, Subcommand};
-use console::style;
-use flate2::read::GzDecoder;
-use regex::Regex;
-use tar::Archive;
+use sindri::client::{AuthOptions, SindriClient};
 
-use sindri::{
-    client::{AuthOptions, SindriClient},
-    CircuitInfo, JobStatus,
-};
+use sindri_cli::commands::{clone, deploy};
 
 #[derive(Parser)]
 #[command(name = "cargo", bin_name = "cargo")]
@@ -60,12 +52,6 @@ pub enum Commands {
     },
 }
 
-fn handle_operation_error(command: &str, message: &str) -> ! {
-    eprintln!("{}", style(format!("{} failed ❌", command)).bold());
-    eprintln!("{}", style(message).red());
-    std::process::exit(1);
-}
-
 fn main() {
     let Cargo::Sindri(args) = Cargo::parse();
 
@@ -78,156 +64,14 @@ fn main() {
 
     match args.command {
         Commands::Clone { circuit, directory } => {
-            println!("{}", style("Cloning...").bold());
-
-            let circuit_regex =
-                Regex::new(r"^(?:([-a-zA-Z0-9_]+)\/)?([-a-zA-Z0-9_]+)(?::([-a-zA-Z0-9_.]+))?$")
-                    .unwrap();
-            let circuit_name = if let Some(captures) = circuit_regex.captures(&circuit) {
-                captures
-                    .get(2)
-                    .map(|m| m.as_str().to_string())
-                    .unwrap_or_else(|| {
-                        handle_operation_error("Clone", "Invalid circuit identifier")
-                    })
-            } else {
-                handle_operation_error("Clone", "Invalid circuit identifier")
-            };
-            let output_directory = directory.unwrap_or(circuit_name.clone());
-            println!(
-                "{}",
-                style(format!("  ✓ Valid circuit identifier: {}", circuit)).cyan()
-            );
-
-            let download_path = {
-                let p = Path::new(&output_directory);
-                if p.is_dir() {
-                    handle_operation_error("Clone", "Output directory already exists");
-                }
-                match fs::create_dir_all(p) {
-                    Ok(_) => p.join("circuit.tar.gz"),
-                    Err(e) => handle_operation_error("Clone", &e.to_string()),
-                }
-            };
-
-            match client
-                .clone_circuit_blocking(&circuit, download_path.to_string_lossy().to_string())
-            {
-                Ok(_) => println!("{}", style("  ✓ Successfully downloaded circuit").cyan()),
-                Err(e) => {
-                    if e.to_string().contains("404") {
-                        handle_operation_error(
-                            "Clone",
-                            "Circuit does not exist or you lack permission to access it.",
-                        );
-                    } else {
-                        handle_operation_error("Clone", &e.to_string());
-                    }
-                }
-            }
-
-            println!("{}", style("  ✓ Unpacking circuit...").cyan());
-            // Unpack the tarball
-            let downloaded = fs::read(&download_path).unwrap();
-            let cursor = Cursor::new(downloaded);
-            let gz_decoder = GzDecoder::new(cursor);
-            let mut archive = Archive::new(gz_decoder);
-
-            // Manually unpack the tarball, stripping the top-level directory
-            (|| -> Result<(), Box<dyn std::error::Error>> {
-                for entry in archive.entries()? {
-                    let mut entry = entry?;
-                    let path = entry.path()?;
-                    if let Some(stripped) =
-                        path.iter().skip(1).collect::<std::path::PathBuf>().to_str()
-                    {
-                        let output_path = Path::new(&output_directory).join(stripped);
-                        if let Some(parent) = output_path.parent() {
-                            fs::create_dir_all(parent)?;
-                        }
-                        entry.unpack(&output_path)?;
-                    }
-                }
-                Ok(())
-            })()
-            .unwrap_or_else(|e| {
-                handle_operation_error("Clone", &format!("Issue unpacking circuit: {}", e))
-            });
-
-            // Remove the download tarball
-            std::fs::remove_file(&download_path).unwrap();
-
-            println!("{}", style("  ✓ Circuit cloned successfully!").cyan());
-            println!(
-                "\n{}",
-                style(format!("Circuit downloaded to: {}", output_directory)).bold()
-            );
+            clone(&client, circuit, directory);
         }
-
         Commands::Deploy {
             project,
             tags,
             meta,
         } => {
-            println!("{}", style("Deploying...").bold());
-
-            // Convert metadata strings into HashMap
-            let meta_rules = Regex::new(r"^[a-zA-Z0-9]+=[a-zA-Z0-9]+$").unwrap();
-            let metadata = meta.map(|pairs| {
-                pairs
-                    .into_iter()
-                    .filter_map(|pair| {
-                        if meta_rules.is_match(&pair) {
-                            let mut parts = pair.splitn(2, '=');
-                            Some((
-                                parts.next()?.to_string(),
-                                parts.next().unwrap_or_default().to_string(),
-                            ))
-                        } else {
-                            handle_operation_error(
-                                "Deploy",
-                                &format!("\"{pair}\" is not a valid metadata pair."),
-                            );
-                        }
-                    })
-                    .collect::<HashMap<String, String>>()
-            });
-            println!(
-                "{}",
-                style(format!(
-                    "  ✓ Valid metadata pairs specified: {}",
-                    metadata.as_ref().map_or(0, |t| t.len())
-                ))
-                .cyan()
-            );
-
-            match client.create_circuit_blocking(project, tags, metadata) {
-                Ok(response) => {
-                    // Gather circuit identifiers from response
-                    let status = *response.status();
-                    if status == JobStatus::Ready {
-                        let uuid = response.id();
-                        let team = response.team_slug();
-                        let project_name = response.project_name();
-                        let first_tag = response.tags().first().cloned().unwrap_or_default();
-
-                        println!("{}", style("  ✓ Circuit created successfully!").cyan());
-                        println!(
-                            "\n{}",
-                            style("To generate a proof from this deployment, you can use either:")
-                                .bold()
-                        );
-                        println!("• Circuit UUID: {}", style(uuid).cyan());
-                        println!(
-                            "• Identifier:  {}",
-                            style(format!("{}/{}:{}", team, project_name, first_tag)).cyan()
-                        );
-                    } else {
-                        handle_operation_error("Deploy", &response.error().unwrap_or_default())
-                    }
-                }
-                Err(e) => handle_operation_error("Deploy", &e.to_string()),
-            }
+            deploy(&client, project, tags, meta);
         }
     }
 }

--- a/cli/src/bin/cargo-sindri.rs
+++ b/cli/src/bin/cargo-sindri.rs
@@ -59,6 +59,14 @@ pub enum Commands {
         /// Password (if not provided, will prompt for input)
         #[arg(long)]
         password: Option<String>,
+
+        /// Key name (if not provided, will prompt for input)
+        #[arg(long)]
+        keyname: Option<String>,
+
+        /// Team name (if not provided, will prompt for input)
+        #[arg(long)]
+        teamname: Option<String>,
     },
 }
 
@@ -83,8 +91,13 @@ fn main() {
         } => {
             deploy(&client, project, tags, meta);
         }
-        Commands::Login { username, password } => {
-            login(&client, username, password);
+        Commands::Login {
+            username,
+            password,
+            keyname,
+            teamname,
+        } => {
+            login(&client, username, password, keyname, teamname);
         }
     }
 }

--- a/cli/src/bin/cargo-sindri.rs
+++ b/cli/src/bin/cargo-sindri.rs
@@ -196,10 +196,33 @@ mod tests {
             .arg("--username")
             .arg("mockuser")
             .arg("--password")
-            .arg("ಠ_ಠ");
+            .arg("ಠ_ಠ")
+            .arg("--keyname")
+            .arg("my-new-key")
+            .arg("--teamname")
+            .arg("does-not-matter");
 
         cmd.assert()
             .failure()
             .stderr(predicate::str::contains("401 Unauthorized"));
+    }
+
+    #[tokio::test]
+    async fn test_cli_login_keyname_too_long() {
+        let mut cmd = Command::cargo_bin("cargo-sindri").unwrap();
+        cmd.arg("sindri")
+            .arg("login")
+            .arg("--username")
+            .arg("mockuser")
+            .arg("--password")
+            .arg("ಠ_ಠ")
+            .arg("--keyname")
+            .arg("aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa")
+            .arg("--teamname")
+            .arg("does-not-matter");
+
+        cmd.assert().failure().stderr(predicate::str::contains(
+            "API key name must not exceed 32 characters",
+        ));
     }
 }

--- a/cli/src/bin/cargo-sindri.rs
+++ b/cli/src/bin/cargo-sindri.rs
@@ -51,7 +51,15 @@ pub enum Commands {
         meta: Option<Vec<String>>,
     },
     /// Login to Sindri
-    Login,
+    Login {
+        /// Username (if not provided, will prompt for input)
+        #[arg(long)]
+        username: Option<String>,
+
+        /// Password (if not provided, will prompt for input)
+        #[arg(long)]
+        password: Option<String>,
+    },
 }
 
 fn main() {
@@ -75,8 +83,8 @@ fn main() {
         } => {
             deploy(&client, project, tags, meta);
         }
-        Commands::Login => {
-            login(&client);
+        Commands::Login { username, password } => {
+            login(&client, username, password);
         }
     }
 }
@@ -165,5 +173,20 @@ mod tests {
         cmd.assert()
             .failure()
             .stderr(predicate::str::contains("Invalid circuit identifier"));
+    }
+
+    #[tokio::test]
+    async fn test_cli_login_bad_credentials() {
+        let mut cmd = Command::cargo_bin("cargo-sindri").unwrap();
+        cmd.arg("sindri")
+            .arg("login")
+            .arg("--username")
+            .arg("mockuser")
+            .arg("--password")
+            .arg("ಠ_ಠ");
+
+        cmd.assert()
+            .failure()
+            .stderr(predicate::str::contains("401 Unauthorized"));
     }
 }

--- a/cli/src/commands/clone.rs
+++ b/cli/src/commands/clone.rs
@@ -1,0 +1,95 @@
+use std::{fs, io::Cursor, path::Path};
+
+use flate2::read::GzDecoder;
+use regex::Regex;
+use tar::Archive;
+
+use sindri::client::SindriClient;
+
+use crate::handle_operation_error;
+
+pub fn clone(client: &SindriClient, circuit: String, directory: Option<String>) {
+    println!("{}", console::style("Cloning...").bold());
+
+    let circuit_regex =
+        Regex::new(r"^(?:([-a-zA-Z0-9_]+)\/)?([-a-zA-Z0-9_]+)(?::([-a-zA-Z0-9_.]+))?$").unwrap();
+    let circuit_name = if let Some(captures) = circuit_regex.captures(&circuit) {
+        captures
+            .get(2)
+            .map(|m| m.as_str().to_string())
+            .unwrap_or_else(|| handle_operation_error("Clone", "Invalid circuit identifier"))
+    } else {
+        handle_operation_error("Clone", "Invalid circuit identifier")
+    };
+    let output_directory = directory.unwrap_or(circuit_name.clone());
+    println!(
+        "{}",
+        console::style(format!("  ✓ Valid circuit identifier: {}", circuit)).cyan()
+    );
+
+    let download_path = {
+        let p = Path::new(&output_directory);
+        if p.is_dir() {
+            handle_operation_error("Clone", "Output directory already exists");
+        }
+        match fs::create_dir_all(p) {
+            Ok(_) => p.join("circuit.tar.gz"),
+            Err(e) => handle_operation_error("Clone", &e.to_string()),
+        }
+    };
+
+    match client.clone_circuit_blocking(&circuit, download_path.to_string_lossy().to_string()) {
+        Ok(_) => println!(
+            "{}",
+            console::style("  ✓ Successfully downloaded circuit").cyan()
+        ),
+        Err(e) => {
+            if e.to_string().contains("404") {
+                handle_operation_error(
+                    "Clone",
+                    "Circuit does not exist or you lack permission to access it.",
+                );
+            } else {
+                handle_operation_error("Clone", &e.to_string());
+            }
+        }
+    }
+
+    println!("{}", console::style("  ✓ Unpacking circuit...").cyan());
+    // Unpack the tarball
+    let downloaded = fs::read(&download_path).unwrap();
+    let cursor = Cursor::new(downloaded);
+    let gz_decoder = GzDecoder::new(cursor);
+    let mut archive = Archive::new(gz_decoder);
+
+    // Manually unpack the tarball, stripping the top-level directory
+    (|| -> Result<(), Box<dyn std::error::Error>> {
+        for entry in archive.entries()? {
+            let mut entry = entry?;
+            let path = entry.path()?;
+            if let Some(stripped) = path.iter().skip(1).collect::<std::path::PathBuf>().to_str() {
+                let output_path = Path::new(&output_directory).join(stripped);
+                if let Some(parent) = output_path.parent() {
+                    fs::create_dir_all(parent)?;
+                }
+                entry.unpack(&output_path)?;
+            }
+        }
+        Ok(())
+    })()
+    .unwrap_or_else(|e| {
+        handle_operation_error("Clone", &format!("Issue unpacking circuit: {}", e))
+    });
+
+    // Remove the download tarball
+    std::fs::remove_file(&download_path).unwrap();
+
+    println!(
+        "{}",
+        console::style("  ✓ Circuit cloned successfully!").cyan()
+    );
+    println!(
+        "\n{}",
+        console::style(format!("Circuit downloaded to: {}", output_directory)).bold()
+    );
+}

--- a/cli/src/commands/deploy.rs
+++ b/cli/src/commands/deploy.rs
@@ -1,0 +1,76 @@
+use std::collections::HashMap;
+
+use regex::Regex;
+use sindri::{client::SindriClient, CircuitInfo, JobStatus};
+
+use crate::handle_operation_error;
+
+pub fn deploy(
+    client: &SindriClient,
+    project: String,
+    tags: Option<Vec<String>>,
+    meta: Option<Vec<String>>,
+) {
+    println!("{}", console::style("Deploying...").bold());
+
+    // Convert metadata strings into HashMap
+    let meta_rules = Regex::new(r"^[a-zA-Z0-9]+=[a-zA-Z0-9]+$").unwrap();
+    let metadata = meta.map(|pairs| {
+        pairs
+            .into_iter()
+            .filter_map(|pair| {
+                if meta_rules.is_match(&pair) {
+                    let mut parts = pair.splitn(2, '=');
+                    Some((
+                        parts.next()?.to_string(),
+                        parts.next().unwrap_or_default().to_string(),
+                    ))
+                } else {
+                    handle_operation_error(
+                        "Deploy",
+                        &format!("\"{pair}\" is not a valid metadata pair."),
+                    );
+                }
+            })
+            .collect::<HashMap<String, String>>()
+    });
+    println!(
+        "{}",
+        console::style(format!(
+            "  ✓ Valid metadata pairs specified: {}",
+            metadata.as_ref().map_or(0, |t| t.len())
+        ))
+        .cyan()
+    );
+
+    match client.create_circuit_blocking(project, tags, metadata) {
+        Ok(response) => {
+            // Gather circuit identifiers from response
+            let status = *response.status();
+            if status == JobStatus::Ready {
+                let uuid = response.id();
+                let team = response.team_slug();
+                let project_name = response.project_name();
+                let first_tag = response.tags().first().cloned().unwrap_or_default();
+
+                println!(
+                    "{}",
+                    console::style("  ✓ Circuit created successfully!").cyan()
+                );
+                println!(
+                    "\n{}",
+                    console::style("To generate a proof from this deployment, you can use either:")
+                        .bold()
+                );
+                println!("• Circuit UUID: {}", console::style(uuid).cyan());
+                println!(
+                    "• Identifier:  {}",
+                    console::style(format!("{}/{}:{}", team, project_name, first_tag)).cyan()
+                );
+            } else {
+                handle_operation_error("Deploy", &response.error().unwrap_or_default())
+            }
+        }
+        Err(e) => handle_operation_error("Deploy", &e.to_string()),
+    }
+}

--- a/cli/src/commands/login.rs
+++ b/cli/src/commands/login.rs
@@ -2,18 +2,24 @@ use dialoguer::{Input, Password, Select};
 use sindri::{client::SindriClient, TeamDetail};
 use crate::handle_operation_error;
 
-pub fn login(client: &SindriClient) {
+pub fn login(client: &SindriClient, username: Option<String>, password: Option<String>) {
     println!("{}", console::style("Logging in...").bold());
 
-    let username: String = Input::new()
-        .with_prompt("Username")
-        .interact_text()
-        .unwrap_or_else(|e| handle_operation_error("Login", &e.to_string()));
+    let username = match username {
+        Some(u) => u,
+        None => Input::new()
+            .with_prompt("Username")
+            .interact_text()
+            .unwrap_or_else(|e| handle_operation_error("Login", &e.to_string())),
+    };
 
-    let password: String = Password::new()
-        .with_prompt("Password")
-        .interact()
-        .unwrap_or_else(|e| handle_operation_error("Login", &e.to_string()));
+    let password = match password {
+        Some(p) => p,
+        None => Password::new()
+            .with_prompt("Password")
+            .interact()
+            .unwrap_or_else(|e| handle_operation_error("Login", &e.to_string())),
+    };
 
     // Generate an initial JWT token for team retrieval
     let rt = tokio::runtime::Runtime::new().unwrap();

--- a/cli/src/commands/login.rs
+++ b/cli/src/commands/login.rs
@@ -1,6 +1,6 @@
+use crate::handle_operation_error;
 use dialoguer::{Input, Password, Select};
 use sindri::{client::SindriClient, TeamDetail};
-use crate::handle_operation_error;
 
 pub fn login(client: &SindriClient, username: Option<String>, password: Option<String>) {
     println!("{}", console::style("Logging in...").bold());
@@ -45,15 +45,28 @@ pub fn login(client: &SindriClient, username: Option<String>, password: Option<S
         .interact()
         .unwrap_or_else(|e| handle_operation_error("Login", &e.to_string()));
     let selected_team = &teams[selection];
-    
+
     // Generate API key for selected team
-    let api_key = match rt.block_on(client.api_key_select_team(&username, &password, &selected_team.name, &selected_team.id.to_string())) {
+    let api_key = match rt.block_on(client.api_key_select_team(
+        &username,
+        &password,
+        &selected_team.name,
+        &selected_team.id.to_string(),
+    )) {
         Ok(key) => key,
         Err(e) => handle_operation_error("Login", &e.to_string()),
     };
 
-    println!("\n{}", console::style("API key generated successfully!").green().bold());
-    println!("{}", console::style("Please copy this key as it will only be shown once:").bold());
+    println!(
+        "\n{}",
+        console::style("API key generated successfully!")
+            .green()
+            .bold()
+    );
+    println!(
+        "{}",
+        console::style("Please copy this key as it will only be shown once:").bold()
+    );
     println!("{}", console::style(api_key).cyan());
     println!("\n{}", console::style("You can now use this key with the --api-key flag or set `SINDRI_API_KEY` in your environment variables.").dim());
-} 
+}

--- a/cli/src/commands/login.rs
+++ b/cli/src/commands/login.rs
@@ -8,7 +8,7 @@ pub fn login(client: &SindriClient, username: Option<String>, password: Option<S
     let username = match username {
         Some(u) => u,
         None => Input::new()
-            .with_prompt("Username")
+            .with_prompt("  Username")
             .interact_text()
             .unwrap_or_else(|e| handle_operation_error("Login", &e.to_string())),
     };
@@ -16,13 +16,13 @@ pub fn login(client: &SindriClient, username: Option<String>, password: Option<S
     let password = match password {
         Some(p) => p,
         None => Password::new()
-            .with_prompt("Password")
+            .with_prompt("  Password")
             .interact()
             .unwrap_or_else(|e| handle_operation_error("Login", &e.to_string())),
     };
 
     let name = Input::new()
-        .with_prompt("New API Key Name")
+        .with_prompt("  New API Key Name")
         .with_initial_text(format!("{}-rust-sdk", username))
         .validate_with(|input: &String| -> Result<(), String> {
             if input.len() > 32 {
@@ -40,6 +40,7 @@ pub fn login(client: &SindriClient, username: Option<String>, password: Option<S
         Ok(token) => token,
         Err(e) => handle_operation_error("Login", &e.to_string()),
     };
+    println!("{}", console::style("  ✓ Valid credentials").cyan());
 
     // Collect list of teams for the user
     let teams = match rt.block_on(client.teams_jwt_auth(&token)) {
@@ -53,13 +54,11 @@ pub fn login(client: &SindriClient, username: Option<String>, password: Option<S
     // Let user select a team
     let team_names: Vec<String> = teams.iter().map(|t: &TeamDetail| t.slug.clone()).collect();
     let selection = Select::new()
-        .with_prompt("Select a team to generate an API key for")
+        .with_prompt("  Select a team to generate an API key for")
         .items(&team_names)
         .interact()
         .unwrap_or_else(|e| handle_operation_error("Login", &e.to_string()));
     let selected_team = &teams[selection];
-
-
 
     // Generate API key for selected team
     let api_key = match rt.block_on(client.api_key_select_team(
@@ -73,15 +72,25 @@ pub fn login(client: &SindriClient, username: Option<String>, password: Option<S
     };
 
     println!(
+        "{}",
+        console::style("  ✓ API key generated successfully!").cyan()
+    );
+
+    println!(
         "\n{}",
-        console::style("API key generated successfully!")
-            .green()
-            .bold()
+        console::style("To authenticate future requests with the rust SDK, you can either:").bold()
     );
     println!(
-        "{}",
-        console::style("Please copy this key as it will only be shown once:").bold()
+        "• Set SINDRI_API_KEY={} in your environment variables",
+        console::style(&api_key).cyan()
     );
-    println!("{}", console::style(api_key).cyan());
-    println!("\n{}", console::style("You can now use this key with the --api-key flag or set `SINDRI_API_KEY` in your environment variables.").dim());
+    println!(
+        "• Supply --api-key={} in any `cargo sindri` command",
+        console::style(&api_key).cyan()
+    );
+
+    println!(
+        "\n{}",
+        console::style("Make sure to keep track of this key as it will only be shown once").dim()
+    );
 }

--- a/cli/src/commands/login.rs
+++ b/cli/src/commands/login.rs
@@ -1,0 +1,53 @@
+use dialoguer::{Input, Password, Select};
+use sindri::{client::SindriClient, TeamDetail};
+use crate::handle_operation_error;
+
+pub fn login(client: &SindriClient) {
+    println!("{}", console::style("Logging in...").bold());
+
+    let username: String = Input::new()
+        .with_prompt("Username")
+        .interact_text()
+        .unwrap_or_else(|e| handle_operation_error("Login", &e.to_string()));
+
+    let password: String = Password::new()
+        .with_prompt("Password")
+        .interact()
+        .unwrap_or_else(|e| handle_operation_error("Login", &e.to_string()));
+
+    // Generate an initial JWT token for team retrieval
+    let rt = tokio::runtime::Runtime::new().unwrap();
+    let token = match rt.block_on(client.jwt_token_generate(&username, &password)) {
+        Ok(token) => token,
+        Err(e) => handle_operation_error("Login", &e.to_string()),
+    };
+
+    // Collect list of teams for the user
+    let teams = match rt.block_on(client.teams_jwt_auth(&token)) {
+        Ok(teams) => teams,
+        Err(e) => handle_operation_error("Login", &e.to_string()),
+    };
+    if teams.is_empty() {
+        handle_operation_error("Login", "No teams found for this user");
+    }
+
+    // Let user select a team
+    let team_names: Vec<String> = teams.iter().map(|t: &TeamDetail| t.slug.clone()).collect();
+    let selection = Select::new()
+        .with_prompt("Select a team to generate an API key for")
+        .items(&team_names)
+        .interact()
+        .unwrap_or_else(|e| handle_operation_error("Login", &e.to_string()));
+    let selected_team = &teams[selection];
+    
+    // Generate API key for selected team
+    let api_key = match rt.block_on(client.api_key_select_team(&username, &password, &selected_team.name, &selected_team.id.to_string())) {
+        Ok(key) => key,
+        Err(e) => handle_operation_error("Login", &e.to_string()),
+    };
+
+    println!("\n{}", console::style("API key generated successfully!").green().bold());
+    println!("{}", console::style("Please copy this key as it will only be shown once:").bold());
+    println!("{}", console::style(api_key).cyan());
+    println!("\n{}", console::style("You can now use this key with the --api-key flag or set `SINDRI_API_KEY` in your environment variables.").dim());
+} 

--- a/cli/src/commands/login.rs
+++ b/cli/src/commands/login.rs
@@ -30,7 +30,7 @@ pub fn login(
     let name = match keyname {
         Some(n) => {
             if n.len() > 32 {
-                handle_operation_error("Login", "API key name must be 32 characters or fewer.");
+                handle_operation_error("Login", "API key name must not exceed 32 characters.");
             }
             n
         }
@@ -39,7 +39,7 @@ pub fn login(
             .with_initial_text(format!("{}-rust-sdk", username))
             .validate_with(|input: &String| -> Result<(), String> {
                 if input.len() > 32 {
-                    Err("API key name must be 32 characters or fewer.".to_string())
+                    Err("API key name must not exceed 32 characters.".to_string())
                 } else {
                     Ok(())
                 }

--- a/cli/src/commands/mod.rs
+++ b/cli/src/commands/mod.rs
@@ -4,6 +4,9 @@ pub use clone::clone;
 pub mod deploy;
 pub use deploy::deploy;
 
+pub mod login;
+pub use login::login;
+
 use console::style;
 
 pub fn handle_operation_error(command: &str, message: &str) -> ! {

--- a/cli/src/commands/mod.rs
+++ b/cli/src/commands/mod.rs
@@ -1,0 +1,13 @@
+pub mod clone;
+pub use clone::clone;
+
+pub mod deploy;
+pub use deploy::deploy;
+
+use console::style;
+
+pub fn handle_operation_error(command: &str, message: &str) -> ! {
+    eprintln!("{}", style(format!("{} failed ❌", command)).bold());
+    eprintln!("{}", style(message).red());
+    std::process::exit(1);
+}

--- a/cli/src/lib.rs
+++ b/cli/src/lib.rs
@@ -1,0 +1,2 @@
+pub mod commands;
+pub use commands::*;

--- a/openapi/patches/export_some_internals.patch
+++ b/openapi/patches/export_some_internals.patch
@@ -10,7 +10,7 @@ index 18c0d9d..9347831 100644
 +#[allow(dead_code)]
 +mod internal_api;
 +pub use internal_api::{
-+    circuit_download, circuit_status, proof_status, CircuitStatusError, ProofStatusError,
++    circuit_download, circuit_status, proof_status, user_me_with_jwt_auth, CircuitStatusError, ProofStatusError,
 +};
  pub mod proofs_api;
  pub mod token_api;

--- a/openapi/src/apis/mod.rs
+++ b/openapi/src/apis/mod.rs
@@ -106,7 +106,8 @@ pub mod circuits_api;
 #[allow(dead_code)]
 mod internal_api;
 pub use internal_api::{
-    circuit_download, circuit_status, proof_status, user_me_with_jwt_auth, CircuitStatusError, ProofStatusError,
+    circuit_download, circuit_status, proof_status, user_me_with_jwt_auth, CircuitStatusError,
+    ProofStatusError,
 };
 pub mod proofs_api;
 pub mod token_api;

--- a/openapi/src/apis/mod.rs
+++ b/openapi/src/apis/mod.rs
@@ -106,7 +106,7 @@ pub mod circuits_api;
 #[allow(dead_code)]
 mod internal_api;
 pub use internal_api::{
-    circuit_download, circuit_status, proof_status, CircuitStatusError, ProofStatusError,
+    circuit_download, circuit_status, proof_status, user_me_with_jwt_auth, CircuitStatusError, ProofStatusError,
 };
 pub mod proofs_api;
 pub mod token_api;

--- a/sindri/src/client.rs
+++ b/sindri/src/client.rs
@@ -116,7 +116,7 @@ impl Default for PollingOptions {
 ///  like uploads of circuits or guest code and proof generation.
 #[derive(Debug)]
 pub struct SindriClient {
-    config: Configuration,
+    pub(crate) config: Configuration,
     pub polling_options: PollingOptions,
 }
 

--- a/sindri/src/jwt.rs
+++ b/sindri/src/jwt.rs
@@ -1,0 +1,72 @@
+//! Methods used by the CLI to authenticate with user/pass before generating an API key
+//! 
+//! These methods should be used with caution outside of the CLI since there are
+//! no checks in place to ensure the token is valid or has not expired.
+
+use sindri_openapi::{
+    apis::{authorization_api::apikey_generate, configuration::Configuration, token_api::jwt_token_generate, user_me_with_jwt_auth},
+    models::{ObtainApikeyInput, TeamDetail, TokenObtainPairInputSchema},
+};
+
+use crate::client::SindriClient;
+
+impl SindriClient {
+    pub async fn jwt_token_generate(
+        &self,
+        username: &str,
+        password: &str,
+    ) -> Result<String, Box<dyn std::error::Error>> {
+        let token = jwt_token_generate(
+            &self.config,
+            TokenObtainPairInputSchema {
+                username: username.to_string(),
+                password: password.to_string(),
+            },
+        )
+        .await?;
+
+        Ok(token.access)
+    }
+
+    pub async fn teams_jwt_auth(
+        &self,
+        token: &str,
+    ) -> Result<Vec<TeamDetail>, Box<dyn std::error::Error>> {
+        let config = Configuration {
+            base_path: self.config.base_path.clone(),
+            client: self.config.client.clone(),
+            bearer_access_token: Some(token.to_string()),
+            ..Default::default()
+        };
+        let user = user_me_with_jwt_auth(&config).await?;
+
+        Ok(user.teams)
+    }
+
+    pub async fn api_key_from_jwt_team(
+        &self,
+        username: &str,
+        password: &str,
+        key_name: &str,
+        team_id: &str,
+    ) -> Result<String, Box<dyn std::error::Error>> {
+        let api_key = apikey_generate(
+            &self.config,
+            ObtainApikeyInput {
+                username: username.to_string(),
+                password: password.to_string(),
+                name: Some(key_name.to_string()),
+            },
+            Some(team_id),
+        )
+        .await?;
+
+        if let Some(api_key) = api_key.api_key {
+            Ok(api_key)
+        } else {
+            Err("Failed to generate API key".into())
+        }
+    }
+
+
+}

--- a/sindri/src/jwt.rs
+++ b/sindri/src/jwt.rs
@@ -1,16 +1,22 @@
 //! Methods used by the CLI to authenticate with user/pass before generating an API key
-//! 
+//!
 //! These methods should be used with caution outside of the CLI since there are
-//! no checks in place to ensure the token is valid or has not expired.
+//! no intentional checks in place to ensure the token is valid or has not expired.
 
 use sindri_openapi::{
-    apis::{authorization_api::apikey_generate, configuration::Configuration, token_api::jwt_token_generate, user_me_with_jwt_auth},
+    apis::{
+        authorization_api::apikey_generate, configuration::Configuration,
+        token_api::jwt_token_generate, user_me_with_jwt_auth,
+    },
     models::{ObtainApikeyInput, TeamDetail, TokenObtainPairInputSchema},
 };
 
 use crate::client::SindriClient;
 
 impl SindriClient {
+    /// Generate and return a JWT token from a username and password
+    ///
+    /// A nonstandard base URL is passed through the SindriClient
     pub async fn jwt_token_generate(
         &self,
         username: &str,
@@ -28,6 +34,10 @@ impl SindriClient {
         Ok(token.access)
     }
 
+    /// Get the teams for a user
+    ///
+    /// Any API key attached to the SindriClient is replaced with
+    /// the input JWT token.
     pub async fn teams_jwt_auth(
         &self,
         token: &str,
@@ -43,7 +53,11 @@ impl SindriClient {
         Ok(user.teams)
     }
 
-    pub async fn api_key_from_jwt_team(
+    /// Generate an API key from a username and password
+    ///
+    /// A `Sindri-Team-Id` header is passed to the API to select the
+    /// team for which the API key will be generated.
+    pub async fn api_key_select_team(
         &self,
         username: &str,
         password: &str,
@@ -67,6 +81,97 @@ impl SindriClient {
             Err("Failed to generate API key".into())
         }
     }
+}
 
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use sindri_openapi::models::{ApiKeyResponse, TokenObtainPairOutputSchema, UserMeResponse};
+    use wiremock::{
+        matchers::{method, path},
+        Mock, MockServer, ResponseTemplate,
+    };
 
+    async fn mock_auth_server() -> MockServer {
+        let mock_server = MockServer::start().await;
+
+        Mock::given(method("POST"))
+            .and(path("/api/token/pair"))
+            .respond_with(
+                ResponseTemplate::new(200).set_body_json(TokenObtainPairOutputSchema {
+                    access: "test_jwt_token".to_string(),
+                    refresh: "test_refresh_token".to_string(),
+                    ..Default::default()
+                }),
+            )
+            .mount(&mock_server)
+            .await;
+
+        Mock::given(method("GET"))
+            .and(path("/api/v1/user/me"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(UserMeResponse {
+                teams: vec![TeamDetail {
+                    id: 1,
+                    name: "Team One".to_string(),
+                    ..Default::default()
+                }],
+                ..Default::default()
+            }))
+            .mount(&mock_server)
+            .await;
+
+        Mock::given(method("POST"))
+            .and(path("/api/apikey/generate"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(ApiKeyResponse {
+                api_key: Some("test_api_key_123".to_string()),
+                ..Default::default()
+            }))
+            .mount(&mock_server)
+            .await;
+
+        mock_server
+    }
+
+    #[tokio::test]
+    async fn test_jwt_token_generate() {
+        let mock_server = mock_auth_server().await;
+
+        let mut client = SindriClient::default();
+        client.config.base_path = mock_server.uri().to_string();
+
+        let token = client
+            .jwt_token_generate("test_user", "test_pass")
+            .await
+            .unwrap();
+
+        assert_eq!(token, "test_jwt_token");
+    }
+
+    #[tokio::test]
+    async fn test_teams_jwt_auth() {
+        let mock_server = mock_auth_server().await;
+
+        let mut client = SindriClient::default();
+        client.config.base_path = mock_server.uri().to_string();
+
+        let teams = client.teams_jwt_auth("test_jwt_token").await.unwrap();
+
+        assert_eq!(teams.len(), 1);
+        assert_eq!(teams[0].id, 1);
+    }
+
+    #[tokio::test]
+    async fn test_api_key_select_team() {
+        let mock_server = mock_auth_server().await;
+
+        let mut client = SindriClient::default();
+        client.config.base_path = mock_server.uri().to_string();
+
+        let api_key = client
+            .api_key_select_team("test_user", "test_pass", "test_key", "team1")
+            .await
+            .unwrap();
+
+        assert_eq!(api_key, "test_api_key_123");
+    }
 }

--- a/sindri/src/lib.rs
+++ b/sindri/src/lib.rs
@@ -62,6 +62,7 @@
 pub mod client;
 
 pub(crate) mod custom_middleware;
+pub(crate) mod jwt;
 pub(crate) mod utils;
 
 pub mod integrations;

--- a/sindri/src/types.rs
+++ b/sindri/src/types.rs
@@ -5,7 +5,7 @@ pub use sindri_openapi::models::{
     GnarkCircuitInfoResponse, Halo2CircuitInfoResponse, HermezCircuitInfoResponse, JobStatus,
     JoltCircuitInfoResponse, NoirCircuitInfoResponse, Plonky2CircuitInfoResponse,
     ProofInfoResponse, ProofInput as InternalProofInput, SnarkvmCircuitInfoResponse,
-    Sp1CircuitInfoResponse,
+    Sp1CircuitInfoResponse, TeamDetail
 };
 use std::collections::HashMap;
 

--- a/sindri/src/types.rs
+++ b/sindri/src/types.rs
@@ -5,7 +5,7 @@ pub use sindri_openapi::models::{
     GnarkCircuitInfoResponse, Halo2CircuitInfoResponse, HermezCircuitInfoResponse, JobStatus,
     JoltCircuitInfoResponse, NoirCircuitInfoResponse, Plonky2CircuitInfoResponse,
     ProofInfoResponse, ProofInput as InternalProofInput, SnarkvmCircuitInfoResponse,
-    Sp1CircuitInfoResponse, TeamDetail
+    Sp1CircuitInfoResponse, TeamDetail,
 };
 use std::collections::HashMap;
 


### PR DESCRIPTION
### 🔄 Pull Request

#### 📝 Description

This introduces `cargo sindri login` which allows users to generate an API key from their user/pw credentials without having to visit the frontend or use our other CLI.  A few methods are introduced in the `SindriClient` that enable this.

#### 🔗 Related Tickets & Documents

- Related Issue #
- Closes #35 

#### 📋 Type of PR (check all applicable)

- [ ] 🔨 Refactor
- [x] ✨ Feature
- [ ] 🐛 Bug Fix
- [ ] ⚡ Optimization
- [ ] 📚 Documentation Update

#### 💭 Developer Notes

* While most of the `SindriClient` methods are in `sindri/src/client.rs`, that file is getting a little beefy.  So we are starting a transition here of moving related methods into their own separate files for better extensibility.  
* You will see that I added to `openapi`.  This is because JWT methods are internal and not recommended for general use cases.  So our openapi schema generates code that makes the endpoints unavailable outside the `openapi` package.  What I did was expose the methods we need in `src/apis/mod.rs` and add this change to a patch file so that it will automatically be added the next time we update the client

#### 🧪 Testing Instructions

You can test the functionality locally via
```
git checkout klm-cargo-sindri-login
cargo install --path cli/ --force --locked
cargo sindri login
```
If you want to use one of our non-production environments, you could pass them in via `--base-url blah` in the command above.  

#### ✅ Testing Status
- [x] Yes, tests added/updated (unit tests added for `sindri` jwt methods and cli unauthorized error)
- [ ] No tests needed because: _please explain why_
- [ ] Help needed with testing
